### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@types/chai": "4.3.5",
         "@types/mocha": "10.0.1",
         "@types/node": "20.4.2",
-        "@typescript-eslint/eslint-plugin": "6.0.0",
-        "@typescript-eslint/parser": "6.0.0",
+        "@typescript-eslint/eslint-plugin": "6.1.0",
+        "@typescript-eslint/parser": "6.1.0",
         "chai": "4.3.7",
         "clean-webpack-plugin": "4.0.0",
         "eslint": "8.45.0",
@@ -23,11 +23,11 @@
         "eslint-webpack-plugin": "4.0.1",
         "mocha": "10.2.0",
         "nodemon": "3.0.1",
-        "npm-check-updates": "16.10.15",
+        "npm-check-updates": "16.10.16",
         "ts-loader": "9.4.4",
         "ts-node": "10.9.1",
         "typescript": "5.1.6",
-        "webpack": "5.88.1",
+        "webpack": "5.88.2",
         "webpack-cli": "5.1.4"
       }
     },
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -842,23 +842,22 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.0.0.tgz",
-      "integrity": "sha512-xuv6ghKGoiq856Bww/yVYnXGsKa588kY3M0XK7uUW/3fJNNULKRfZfSBkMTSpqGG/8ZCXCadfh8G/z/B4aqS/A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.1.0.tgz",
+      "integrity": "sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.0",
-        "@typescript-eslint/scope-manager": "6.0.0",
-        "@typescript-eslint/type-utils": "6.0.0",
-        "@typescript-eslint/utils": "6.0.0",
-        "@typescript-eslint/visitor-keys": "6.0.0",
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/type-utils": "6.1.0",
+        "@typescript-eslint/utils": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4",
-        "grapheme-splitter": "^1.0.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
         "natural-compare": "^1.4.0",
         "natural-compare-lite": "^1.4.0",
-        "semver": "^7.5.0",
+        "semver": "^7.5.4",
         "ts-api-utils": "^1.0.1"
       },
       "engines": {
@@ -879,15 +878,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.0.0.tgz",
-      "integrity": "sha512-TNaufYSPrr1U8n+3xN+Yp9g31vQDJqhXzzPSHfQDLcaO4tU+mCfODPxCwf4H530zo7aUBE3QIdxCXamEnG04Tg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.1.0.tgz",
+      "integrity": "sha512-hIzCPvX4vDs4qL07SYzyomamcs2/tQYXg5DtdAfj35AyJ5PIUqhsLf4YrEIFzZcND7R2E8tpQIZKayxg8/6Wbw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.0.0",
-        "@typescript-eslint/types": "6.0.0",
-        "@typescript-eslint/typescript-estree": "6.0.0",
-        "@typescript-eslint/visitor-keys": "6.0.0",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -907,13 +906,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.0.0.tgz",
-      "integrity": "sha512-o4q0KHlgCZTqjuaZ25nw5W57NeykZT9LiMEG4do/ovwvOcPnDO1BI5BQdCsUkjxFyrCL0cSzLjvIMfR9uo7cWg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.1.0.tgz",
+      "integrity": "sha512-AxjgxDn27hgPpe2rQe19k0tXw84YCOsjDJ2r61cIebq1t+AIxbgiXKvD4999Wk49GVaAcdJ/d49FYel+Pp3jjw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.0.0",
-        "@typescript-eslint/visitor-keys": "6.0.0"
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -924,13 +923,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.0.0.tgz",
-      "integrity": "sha512-ah6LJvLgkoZ/pyJ9GAdFkzeuMZ8goV6BH7eC9FPmojrnX9yNCIsfjB+zYcnex28YO3RFvBkV6rMV6WpIqkPvoQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.1.0.tgz",
+      "integrity": "sha512-kFXBx6QWS1ZZ5Ni89TyT1X9Ag6RXVIVhqDs0vZE/jUeWlBv/ixq2diua6G7ece6+fXw3TvNRxP77/5mOMusx2w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.0.0",
-        "@typescript-eslint/utils": "6.0.0",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/utils": "6.1.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -951,9 +950,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.0.0.tgz",
-      "integrity": "sha512-Zk9KDggyZM6tj0AJWYYKgF0yQyrcnievdhG0g5FqyU3Y2DRxJn4yWY21sJC0QKBckbsdKKjYDV2yVrrEvuTgxg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-+Gfd5NHCpDoHDOaU/yIF3WWRI2PcBRKKpP91ZcVbL0t5tQpqYWBs3z/GGhvU+EV1D0262g9XCnyqQh19prU0JQ==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -964,17 +963,17 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.0.0.tgz",
-      "integrity": "sha512-2zq4O7P6YCQADfmJ5OTDQTP3ktajnXIRrYAtHM9ofto/CJZV3QfJ89GEaM2BNGeSr1KgmBuLhEkz5FBkS2RQhQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.1.0.tgz",
+      "integrity": "sha512-nUKAPWOaP/tQjU1IQw9sOPCDavs/iU5iYLiY/6u7gxS7oKQoi4aUxXS1nrrVGTyBBaGesjkcwwHkbkiD5eBvcg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.0.0",
-        "@typescript-eslint/visitor-keys": "6.0.0",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.5.0",
+        "semver": "^7.5.4",
         "ts-api-utils": "^1.0.1"
       },
       "engines": {
@@ -991,19 +990,18 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.0.0.tgz",
-      "integrity": "sha512-SOr6l4NB6HE4H/ktz0JVVWNXqCJTOo/mHnvIte1ZhBQ0Cvd04x5uKZa3zT6tiodL06zf5xxdK8COiDvPnQ27JQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.1.0.tgz",
+      "integrity": "sha512-wp652EogZlKmQoMS5hAvWqRKplXvkuOnNzZSE0PVvsKjpexd/XznRVHAtrfHFYmqaJz0DFkjlDsGYC9OXw+OhQ==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.3.0",
-        "@types/json-schema": "^7.0.11",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "6.0.0",
-        "@typescript-eslint/types": "6.0.0",
-        "@typescript-eslint/typescript-estree": "6.0.0",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.5.0"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1017,12 +1015,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.0.0.tgz",
-      "integrity": "sha512-cvJ63l8c0yXdeT5POHpL0Q1cZoRcmRKFCtSjNGJxPkcP571EfZMcNbzWAc7oK3D1dRzm/V5EwtkANTZxqvuuUA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.1.0.tgz",
+      "integrity": "sha512-yQeh+EXhquh119Eis4k0kYhj9vmFzNpbhM3LftWQVwqVjipCkwHBQOZutcYW+JVkjtTG9k8nrZU1UoNedPDd1A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.0.0",
+        "@typescript-eslint/types": "6.1.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -3714,12 +3712,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "dev": true
-    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -5509,9 +5501,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "16.10.15",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.10.15.tgz",
-      "integrity": "sha512-tmbFF7J1mIbjmnN4DzFRVlEeAaIB/FPRz4o95DWsGB7fT3ZECuxyMMDnvySfoijuWxx8E7pODN0IoKYnEJVxcg==",
+      "version": "16.10.16",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.10.16.tgz",
+      "integrity": "sha512-d8mNYce/l8o5RHPE5ZUp2P1zj9poI7KWQCh5AsTIP3EhicONEhc63mLQQv4/nkCsMb3wCrikx6YOo4BOwN4+1w==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.3.0",
@@ -8041,9 +8033,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.88.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+      "version": "5.88.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
+      "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "@types/chai": "4.3.5",
     "@types/mocha": "10.0.1",
     "@types/node": "20.4.2",
-    "@typescript-eslint/eslint-plugin": "6.0.0",
-    "@typescript-eslint/parser": "6.0.0",
+    "@typescript-eslint/eslint-plugin": "6.1.0",
+    "@typescript-eslint/parser": "6.1.0",
     "chai": "4.3.7",
     "clean-webpack-plugin": "4.0.0",
     "eslint": "8.45.0",
@@ -57,8 +57,8 @@
     "ts-loader": "9.4.4",
     "ts-node": "10.9.1",
     "typescript": "5.1.6",
-    "webpack": "5.88.1",
+    "webpack": "5.88.2",
     "webpack-cli": "5.1.4",
-    "npm-check-updates": "16.10.15"
+    "npm-check-updates": "16.10.16"
   }
 }


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ @typescript-eslint/eslint-plugin     6.0.0  →     6.1.0
⬆️ @typescript-eslint/parser            6.0.0  →     6.1.0
⬆️ npm-check-updates                 16.10.15  →  16.10.16
⬆️ webpack                             5.88.1  →    5.88.2