### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "devDependencies": {
         "@types/chai": "4.3.5",
         "@types/mocha": "10.0.1",
-        "@types/node": "20.4.2",
-        "@typescript-eslint/eslint-plugin": "6.1.0",
-        "@typescript-eslint/parser": "6.1.0",
+        "@types/node": "20.4.4",
+        "@typescript-eslint/eslint-plugin": "6.2.0",
+        "@typescript-eslint/parser": "6.2.0",
         "chai": "4.3.7",
         "clean-webpack-plugin": "4.0.0",
         "eslint": "8.45.0",
@@ -815,9 +815,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
-      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==",
+      "version": "20.4.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.4.tgz",
+      "integrity": "sha512-CukZhumInROvLq3+b5gLev+vgpsIqC2D0deQr/yS1WnxvmYLlJXZpaQrQiseMY+6xusl79E04UjWoqyr+t1/Ew==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -842,16 +842,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.1.0.tgz",
-      "integrity": "sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.2.0.tgz",
+      "integrity": "sha512-rClGrMuyS/3j0ETa1Ui7s6GkLhfZGKZL3ZrChLeAiACBE/tRc1wq8SNZESUuluxhLj9FkUefRs2l6bCIArWBiQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/type-utils": "6.1.0",
-        "@typescript-eslint/utils": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.2.0",
+        "@typescript-eslint/type-utils": "6.2.0",
+        "@typescript-eslint/utils": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -878,15 +878,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.1.0.tgz",
-      "integrity": "sha512-hIzCPvX4vDs4qL07SYzyomamcs2/tQYXg5DtdAfj35AyJ5PIUqhsLf4YrEIFzZcND7R2E8tpQIZKayxg8/6Wbw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.2.0.tgz",
+      "integrity": "sha512-igVYOqtiK/UsvKAmmloQAruAdUHihsOCvplJpplPZ+3h4aDkC/UKZZNKgB6h93ayuYLuEymU3h8nF1xMRbh37g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/typescript-estree": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.2.0",
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/typescript-estree": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -906,13 +906,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.1.0.tgz",
-      "integrity": "sha512-AxjgxDn27hgPpe2rQe19k0tXw84YCOsjDJ2r61cIebq1t+AIxbgiXKvD4999Wk49GVaAcdJ/d49FYel+Pp3jjw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.0.tgz",
+      "integrity": "sha512-1ZMNVgm5nnHURU8ZSJ3snsHzpFeNK84rdZjluEVBGNu7jDymfqceB3kdIZ6A4xCfEFFhRIB6rF8q/JIqJd2R0Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0"
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -923,13 +923,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.1.0.tgz",
-      "integrity": "sha512-kFXBx6QWS1ZZ5Ni89TyT1X9Ag6RXVIVhqDs0vZE/jUeWlBv/ixq2diua6G7ece6+fXw3TvNRxP77/5mOMusx2w==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.2.0.tgz",
+      "integrity": "sha512-DnGZuNU2JN3AYwddYIqrVkYW0uUQdv0AY+kz2M25euVNlujcN2u+rJgfJsBFlUEzBB6OQkUqSZPyuTLf2bP5mw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.1.0",
-        "@typescript-eslint/utils": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.2.0",
+        "@typescript-eslint/utils": "6.2.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -950,9 +950,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.1.0.tgz",
-      "integrity": "sha512-+Gfd5NHCpDoHDOaU/yIF3WWRI2PcBRKKpP91ZcVbL0t5tQpqYWBs3z/GGhvU+EV1D0262g9XCnyqQh19prU0JQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.0.tgz",
+      "integrity": "sha512-1nRRaDlp/XYJQLvkQJG5F3uBTno5SHPT7XVcJ5n1/k2WfNI28nJsvLakxwZRNY5spuatEKO7d5nZWsQpkqXwBA==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -963,13 +963,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.1.0.tgz",
-      "integrity": "sha512-nUKAPWOaP/tQjU1IQw9sOPCDavs/iU5iYLiY/6u7gxS7oKQoi4aUxXS1nrrVGTyBBaGesjkcwwHkbkiD5eBvcg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.0.tgz",
+      "integrity": "sha512-Mts6+3HQMSM+LZCglsc2yMIny37IhUgp1Qe8yJUYVyO6rHP7/vN0vajKu3JvHCBIy8TSiKddJ/Zwu80jhnGj1w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/visitor-keys": "6.2.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -990,17 +990,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.1.0.tgz",
-      "integrity": "sha512-wp652EogZlKmQoMS5hAvWqRKplXvkuOnNzZSE0PVvsKjpexd/XznRVHAtrfHFYmqaJz0DFkjlDsGYC9OXw+OhQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.2.0.tgz",
+      "integrity": "sha512-RCFrC1lXiX1qEZN8LmLrxYRhOkElEsPKTVSNout8DMzf8PeWoQG7Rxz2SadpJa3VSh5oYKGwt7j7X/VRg+Y3OQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.2.0",
+        "@typescript-eslint/types": "6.2.0",
+        "@typescript-eslint/typescript-estree": "6.2.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1015,12 +1015,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.1.0.tgz",
-      "integrity": "sha512-yQeh+EXhquh119Eis4k0kYhj9vmFzNpbhM3LftWQVwqVjipCkwHBQOZutcYW+JVkjtTG9k8nrZU1UoNedPDd1A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.0.tgz",
+      "integrity": "sha512-QbaYUQVKKo9bgCzpjz45llCfwakyoxHetIy8CAvYCtd16Zu1KrpzNHofwF8kGkpPOxZB2o6kz+0nqH8ZkIzuoQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/types": "6.2.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   "devDependencies": {
     "@types/chai": "4.3.5",
     "@types/mocha": "10.0.1",
-    "@types/node": "20.4.2",
-    "@typescript-eslint/eslint-plugin": "6.1.0",
-    "@typescript-eslint/parser": "6.1.0",
+    "@types/node": "20.4.4",
+    "@typescript-eslint/eslint-plugin": "6.2.0",
+    "@typescript-eslint/parser": "6.2.0",
     "chai": "4.3.7",
     "clean-webpack-plugin": "4.0.0",
     "eslint": "8.45.0",


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ @types/node                       20.4.2  →  20.4.4
⬆️ @typescript-eslint/eslint-plugin   6.1.0  →   6.2.0
⬆️ @typescript-eslint/parser          6.1.0  →   6.2.0