### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,22 +9,22 @@
       "version": "1.0.36",
       "license": "MIT",
       "devDependencies": {
-        "@types/chai": "4.3.6",
+        "@types/chai": "4.3.7",
         "@types/mocha": "10.0.2",
-        "@types/node": "20.8.2",
-        "@typescript-eslint/eslint-plugin": "6.7.4",
-        "@typescript-eslint/parser": "6.7.4",
+        "@types/node": "20.8.4",
+        "@typescript-eslint/eslint-plugin": "6.7.5",
+        "@typescript-eslint/parser": "6.7.5",
         "chai": "4.3.10",
         "clean-webpack-plugin": "4.0.0",
-        "eslint": "8.50.0",
+        "eslint": "8.51.0",
         "eslint-config-prettier": "9.0.0",
         "eslint-plugin-import": "2.28.1",
         "eslint-plugin-prettier": "5.0.0",
         "eslint-webpack-plugin": "4.0.1",
         "mocha": "10.2.0",
         "nodemon": "3.0.1",
-        "npm-check-updates": "16.14.4",
-        "ts-loader": "9.4.4",
+        "npm-check-updates": "16.14.5",
+        "ts-loader": "9.5.0",
         "ts-node": "10.9.1",
         "typescript": "5.2.2",
         "webpack": "5.88.2",
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.50.0.tgz",
-      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
+      "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-VOVRLM1mBxIRxydiViqPcKn6MIxZytrbMpd6RJLIWKxUNr3zux8no0Oc7kJx0WAPIitgZ0gkrDS+btlqQpubpw==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-/k+vesl92vMvMygmQrFe9Aimxi6oQXFUX9mA5HanTrKUSAMoLauSi6PNFOdRw0oeqilaW600GNx2vSaT2f8aIQ==",
       "dev": true
     },
     "node_modules/@types/eslint": {
@@ -815,10 +815,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.2.tgz",
-      "integrity": "sha512-Vvycsc9FQdwhxE3y3DzeIxuEJbWGDsnrxvMADzTDF/lcdR9/K+AQIeAghTQsHtotg/q0j3WEOYS/jQgSdWue3w==",
-      "dev": true
+      "version": "20.8.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.4.tgz",
+      "integrity": "sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.3",
@@ -842,16 +845,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.4.tgz",
-      "integrity": "sha512-DAbgDXwtX+pDkAHwiGhqP3zWUGpW49B7eqmgpPtg+BKJXwdct79ut9+ifqOFPJGClGKSHXn2PTBatCnldJRUoA==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.5.tgz",
+      "integrity": "sha512-JhtAwTRhOUcP96D0Y6KYnwig/MRQbOoLGXTON2+LlyB/N35SP9j1boai2zzwXb7ypKELXMx3DVk9UTaEq1vHEw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.7.4",
-        "@typescript-eslint/type-utils": "6.7.4",
-        "@typescript-eslint/utils": "6.7.4",
-        "@typescript-eslint/visitor-keys": "6.7.4",
+        "@typescript-eslint/scope-manager": "6.7.5",
+        "@typescript-eslint/type-utils": "6.7.5",
+        "@typescript-eslint/utils": "6.7.5",
+        "@typescript-eslint/visitor-keys": "6.7.5",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -877,15 +880,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.4.tgz",
-      "integrity": "sha512-I5zVZFY+cw4IMZUeNCU7Sh2PO5O57F7Lr0uyhgCJmhN/BuTlnc55KxPonR4+EM3GBdfiCyGZye6DgMjtubQkmA==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.5.tgz",
+      "integrity": "sha512-bIZVSGx2UME/lmhLcjdVc7ePBwn7CLqKarUBL4me1C5feOd663liTGjMBGVcGr+BhnSLeP4SgwdvNnnkbIdkCw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.7.4",
-        "@typescript-eslint/types": "6.7.4",
-        "@typescript-eslint/typescript-estree": "6.7.4",
-        "@typescript-eslint/visitor-keys": "6.7.4",
+        "@typescript-eslint/scope-manager": "6.7.5",
+        "@typescript-eslint/types": "6.7.5",
+        "@typescript-eslint/typescript-estree": "6.7.5",
+        "@typescript-eslint/visitor-keys": "6.7.5",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -905,13 +908,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.4.tgz",
-      "integrity": "sha512-SdGqSLUPTXAXi7c3Ob7peAGVnmMoGzZ361VswK2Mqf8UOYcODiYvs8rs5ILqEdfvX1lE7wEZbLyELCW+Yrql1A==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.5.tgz",
+      "integrity": "sha512-GAlk3eQIwWOJeb9F7MKQ6Jbah/vx1zETSDw8likab/eFcqkjSD7BI75SDAeC5N2L0MmConMoPvTsmkrg71+B1A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.7.4",
-        "@typescript-eslint/visitor-keys": "6.7.4"
+        "@typescript-eslint/types": "6.7.5",
+        "@typescript-eslint/visitor-keys": "6.7.5"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -922,13 +925,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.4.tgz",
-      "integrity": "sha512-n+g3zi1QzpcAdHFP9KQF+rEFxMb2KxtnJGID3teA/nxKHOVi3ylKovaqEzGBbVY2pBttU6z85gp0D00ufLzViQ==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.5.tgz",
+      "integrity": "sha512-Gs0qos5wqxnQrvpYv+pf3XfcRXW6jiAn9zE/K+DlmYf6FcpxeNYN0AIETaPR7rHO4K2UY+D0CIbDP9Ut0U4m1g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.7.4",
-        "@typescript-eslint/utils": "6.7.4",
+        "@typescript-eslint/typescript-estree": "6.7.5",
+        "@typescript-eslint/utils": "6.7.5",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -949,9 +952,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.4.tgz",
-      "integrity": "sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.5.tgz",
+      "integrity": "sha512-WboQBlOXtdj1tDFPyIthpKrUb+kZf2VroLZhxKa/VlwLlLyqv/PwUNgL30BlTVZV1Wu4Asu2mMYPqarSO4L5ZQ==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -962,13 +965,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.4.tgz",
-      "integrity": "sha512-ty8b5qHKatlNYd9vmpHooQz3Vki3gG+3PchmtsA4TgrZBKWHNjWfkQid7K7xQogBqqc7/BhGazxMD5vr6Ha+iQ==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.5.tgz",
+      "integrity": "sha512-NhJiJ4KdtwBIxrKl0BqG1Ur+uw7FiOnOThcYx9DpOGJ/Abc9z2xNzLeirCG02Ig3vkvrc2qFLmYSSsaITbKjlg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.7.4",
-        "@typescript-eslint/visitor-keys": "6.7.4",
+        "@typescript-eslint/types": "6.7.5",
+        "@typescript-eslint/visitor-keys": "6.7.5",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -989,17 +992,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.4.tgz",
-      "integrity": "sha512-PRQAs+HUn85Qdk+khAxsVV+oULy3VkbH3hQ8hxLRJXWBEd7iI+GbQxH5SEUSH7kbEoTp6oT1bOwyga24ELALTA==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.5.tgz",
+      "integrity": "sha512-pfRRrH20thJbzPPlPc4j0UNGvH1PjPlhlCMq4Yx7EGjV7lvEeGX0U6MJYe8+SyFutWgSHsdbJ3BXzZccYggezA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.7.4",
-        "@typescript-eslint/types": "6.7.4",
-        "@typescript-eslint/typescript-estree": "6.7.4",
+        "@typescript-eslint/scope-manager": "6.7.5",
+        "@typescript-eslint/types": "6.7.5",
+        "@typescript-eslint/typescript-estree": "6.7.5",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1014,12 +1017,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.4.tgz",
-      "integrity": "sha512-pOW37DUhlTZbvph50x5zZCkFn3xzwkGtNoJHzIM3svpiSkJzwOYr/kVBaXmf+RAQiUDs1AHEZVNPg6UJCJpwRA==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.5.tgz",
+      "integrity": "sha512-3MaWdDZtLlsexZzDSdQWsFQ9l9nL8B80Z4fImSpyllFC/KLqWQRdEcB+gGGO+N3Q2uL40EsG66wZLsohPxNXvg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/types": "6.7.5",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2820,15 +2823,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
-      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
+      "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.50.0",
+        "@eslint/js": "8.51.0",
         "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -5519,9 +5522,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "16.14.4",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.14.4.tgz",
-      "integrity": "sha512-PKg1wv3vno75/9qgRLqV2huBO7eukOlW+PmIGl7LPXjElfYTUTWUtaMOdOckImaSj4Uqe46W/zMbMFZQp5dHRQ==",
+      "version": "16.14.5",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.14.5.tgz",
+      "integrity": "sha512-f7v3YzPUgadtkB2LAVhiWMjrSejJ0N8OM9JjjVfxBz2neHqmPSWQUAUA+U/p3xeXHl9bghRD6knRqBhm9dkRGg==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.3.0",
@@ -7742,15 +7745,16 @@
       }
     },
     "node_modules/ts-loader": {
-      "version": "9.4.4",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.4.tgz",
-      "integrity": "sha512-MLukxDHBl8OJ5Dk3y69IsKVFRA/6MwzEqBgh+OXMPB/OD01KQuWPFd1WAQP8a5PeSCAxfnkhiuWqfmFJzJQt9w==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.0.tgz",
+      "integrity": "sha512-LLlB/pkB4q9mW2yLdFMnK3dEHbrBjeZTYguaaIfusyojBgAGf5kF+O6KcWqiGzWqHk0LBsoolrp4VftEURhybg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.0.0",
         "micromatch": "^4.0.0",
-        "semver": "^7.3.4"
+        "semver": "^7.3.4",
+        "source-map": "^0.7.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7758,6 +7762,15 @@
       "peerDependencies": {
         "typescript": "*",
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/ts-loader/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/ts-node": {
@@ -7932,6 +7945,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
       "dev": true
     },
     "node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -40,25 +40,25 @@
   "homepage": "https://github.com/DailyBotHQ/search-text-highlight#readme",
   "dependencies": {},
   "devDependencies": {
-    "@types/chai": "4.3.6",
+    "@types/chai": "4.3.7",
     "@types/mocha": "10.0.2",
-    "@types/node": "20.8.2",
-    "@typescript-eslint/eslint-plugin": "6.7.4",
-    "@typescript-eslint/parser": "6.7.4",
+    "@types/node": "20.8.4",
+    "@typescript-eslint/eslint-plugin": "6.7.5",
+    "@typescript-eslint/parser": "6.7.5",
     "chai": "4.3.10",
     "clean-webpack-plugin": "4.0.0",
-    "eslint": "8.50.0",
+    "eslint": "8.51.0",
     "eslint-plugin-import": "2.28.1",
     "eslint-plugin-prettier": "5.0.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-webpack-plugin": "4.0.1",
     "mocha": "10.2.0",
     "nodemon": "3.0.1",
-    "ts-loader": "9.4.4",
+    "ts-loader": "9.5.0",
     "ts-node": "10.9.1",
     "typescript": "5.2.2",
     "webpack": "5.88.2",
     "webpack-cli": "5.1.4",
-    "npm-check-updates": "16.14.4"
+    "npm-check-updates": "16.14.5"
   }
 }


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ @types/chai                         4.3.6  →    4.3.7
⬆️ @types/node                        20.8.2  →   20.8.4
⬆️ @typescript-eslint/eslint-plugin    6.7.4  →    6.7.5
⬆️ @typescript-eslint/parser           6.7.4  →    6.7.5
⬆️ eslint                             8.50.0  →   8.51.0
⬆️ npm-check-updates                 16.14.4  →  16.14.5
⬆️ ts-loader                           9.4.4  →    9.5.0