### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,19 +11,19 @@
       "devDependencies": {
         "@types/chai": "4.3.11",
         "@types/mocha": "10.0.6",
-        "@types/node": "20.10.4",
-        "@typescript-eslint/eslint-plugin": "6.14.0",
-        "@typescript-eslint/parser": "6.14.0",
+        "@types/node": "20.10.5",
+        "@typescript-eslint/eslint-plugin": "6.15.0",
+        "@typescript-eslint/parser": "6.15.0",
         "chai": "4.3.10",
         "clean-webpack-plugin": "4.0.0",
-        "eslint": "8.55.0",
+        "eslint": "8.56.0",
         "eslint-config-prettier": "9.1.0",
-        "eslint-plugin-import": "2.29.0",
+        "eslint-plugin-import": "2.29.1",
         "eslint-plugin-prettier": "5.0.1",
         "eslint-webpack-plugin": "4.0.1",
         "mocha": "10.2.0",
         "nodemon": "3.0.2",
-        "npm-check-updates": "16.14.11",
+        "npm-check-updates": "16.14.12",
         "ts-loader": "9.5.1",
         "ts-node": "10.9.2",
         "typescript": "5.3.3",
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
-      "integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -815,9 +815,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.10.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
-      "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -845,16 +845,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.14.0.tgz",
-      "integrity": "sha512-1ZJBykBCXaSHG94vMMKmiHoL0MhNHKSVlcHVYZNw+BKxufhqQVTOawNpwwI1P5nIFZ/4jLVop0mcY6mJJDFNaw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.15.0.tgz",
+      "integrity": "sha512-j5qoikQqPccq9QoBAupOP+CBu8BaJ8BLjaXSioDISeTZkVO3ig7oSIKh3H+rEpee7xCXtWwSB4KIL5l6hWZzpg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.14.0",
-        "@typescript-eslint/type-utils": "6.14.0",
-        "@typescript-eslint/utils": "6.14.0",
-        "@typescript-eslint/visitor-keys": "6.14.0",
+        "@typescript-eslint/scope-manager": "6.15.0",
+        "@typescript-eslint/type-utils": "6.15.0",
+        "@typescript-eslint/utils": "6.15.0",
+        "@typescript-eslint/visitor-keys": "6.15.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -880,15 +880,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.14.0.tgz",
-      "integrity": "sha512-QjToC14CKacd4Pa7JK4GeB/vHmWFJckec49FR4hmIRf97+KXole0T97xxu9IFiPxVQ1DBWrQ5wreLwAGwWAVQA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.15.0.tgz",
+      "integrity": "sha512-MkgKNnsjC6QwcMdlNAel24jjkEO/0hQaMDLqP4S9zq5HBAUJNQB6y+3DwLjX7b3l2b37eNAxMPLwb3/kh8VKdA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.14.0",
-        "@typescript-eslint/types": "6.14.0",
-        "@typescript-eslint/typescript-estree": "6.14.0",
-        "@typescript-eslint/visitor-keys": "6.14.0",
+        "@typescript-eslint/scope-manager": "6.15.0",
+        "@typescript-eslint/types": "6.15.0",
+        "@typescript-eslint/typescript-estree": "6.15.0",
+        "@typescript-eslint/visitor-keys": "6.15.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -908,13 +908,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
-      "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
+      "integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.14.0",
-        "@typescript-eslint/visitor-keys": "6.14.0"
+        "@typescript-eslint/types": "6.15.0",
+        "@typescript-eslint/visitor-keys": "6.15.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -925,13 +925,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
-      "integrity": "sha512-x6OC9Q7HfYKqjnuNu5a7kffIYs3No30isapRBJl1iCHLitD8O0lFbRcVGiOcuyN837fqXzPZ1NS10maQzZMKqw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
+      "integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.14.0",
-        "@typescript-eslint/utils": "6.14.0",
+        "@typescript-eslint/typescript-estree": "6.15.0",
+        "@typescript-eslint/utils": "6.15.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -952,9 +952,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
-      "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
+      "integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -965,13 +965,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
-      "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
+      "integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.14.0",
-        "@typescript-eslint/visitor-keys": "6.14.0",
+        "@typescript-eslint/types": "6.15.0",
+        "@typescript-eslint/visitor-keys": "6.15.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -992,17 +992,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.14.0.tgz",
-      "integrity": "sha512-XwRTnbvRr7Ey9a1NT6jqdKX8y/atWG+8fAIu3z73HSP8h06i3r/ClMhmaF/RGWGW1tHJEwij1uEg2GbEmPYvYg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
+      "integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.14.0",
-        "@typescript-eslint/types": "6.14.0",
-        "@typescript-eslint/typescript-estree": "6.14.0",
+        "@typescript-eslint/scope-manager": "6.15.0",
+        "@typescript-eslint/types": "6.15.0",
+        "@typescript-eslint/typescript-estree": "6.15.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1017,12 +1017,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
-      "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
+      "integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.14.0",
+        "@typescript-eslint/types": "6.15.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2871,15 +2871,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
-      "integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.55.0",
+        "@eslint/js": "8.56.0",
         "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -2984,9 +2984,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
-      "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.7",
@@ -3005,7 +3005,7 @@
         "object.groupby": "^1.0.1",
         "object.values": "^1.1.7",
         "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
+        "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
@@ -5567,9 +5567,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "16.14.11",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.14.11.tgz",
-      "integrity": "sha512-0MMWGbGci22Pu77bR9jRsy5qgxdQSJVqNtSyyFeubDPtbcU36z4gjEDITu26PMabFWPNkAoVfKF31M3uKUvzFg==",
+      "version": "16.14.12",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.14.12.tgz",
+      "integrity": "sha512-5FvqaDX8AqWWTDQFbBllgLwoRXTvzlqVIRSKl9Kg8bYZTfNwMnrp1Zlmb5e/ocf11UjPTc+ShBFjYQ7kg6FL0w==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.3.0",
@@ -7918,9 +7918,9 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",

--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
   "devDependencies": {
     "@types/chai": "4.3.11",
     "@types/mocha": "10.0.6",
-    "@types/node": "20.10.4",
-    "@typescript-eslint/eslint-plugin": "6.14.0",
-    "@typescript-eslint/parser": "6.14.0",
+    "@types/node": "20.10.5",
+    "@typescript-eslint/eslint-plugin": "6.15.0",
+    "@typescript-eslint/parser": "6.15.0",
     "chai": "4.3.10",
     "clean-webpack-plugin": "4.0.0",
-    "eslint": "8.55.0",
-    "eslint-plugin-import": "2.29.0",
+    "eslint": "8.56.0",
+    "eslint-plugin-import": "2.29.1",
     "eslint-plugin-prettier": "5.0.1",
     "eslint-config-prettier": "9.1.0",
     "eslint-webpack-plugin": "4.0.1",
@@ -59,6 +59,6 @@
     "typescript": "5.3.3",
     "webpack": "5.89.0",
     "webpack-cli": "5.1.4",
-    "npm-check-updates": "16.14.11"
+    "npm-check-updates": "16.14.12"
   }
 }


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ @types/node                        20.10.4  →   20.10.5
⬆️ @typescript-eslint/eslint-plugin    6.14.0  →    6.15.0
⬆️ @typescript-eslint/parser           6.14.0  →    6.15.0
⬆️ eslint                              8.55.0  →    8.56.0
⬆️ eslint-plugin-import                2.29.0  →    2.29.1
⬆️ npm-check-updates                 16.14.11  →  16.14.12