### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "@types/glob": "8.1.0",
         "@types/minimatch": "5.1.2",
         "@types/mocha": "10.0.7",
-        "@types/node": "22.5.2",
-        "@typescript-eslint/eslint-plugin": "8.4.0",
-        "@typescript-eslint/parser": "8.4.0",
+        "@types/node": "22.5.4",
+        "@typescript-eslint/eslint-plugin": "8.5.0",
+        "@typescript-eslint/parser": "8.5.0",
         "chai": "4.4.1",
         "clean-webpack-plugin": "4.0.0",
         "eslint": "8.57.0",
@@ -28,7 +28,7 @@
         "npm-check-updates": "17.1.1",
         "ts-loader": "9.5.1",
         "ts-node": "10.9.2",
-        "typescript": "5.5.4",
+        "typescript": "5.6.2",
         "webpack": "5.94.0",
         "webpack-cli": "5.1.4"
       },
@@ -507,9 +507,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.2.tgz",
-      "integrity": "sha512-acJsPTEqYqulZS/Yp/S3GgeE6GZ0qYODUR8aVr/DkhHQ8l9nd4j5x1/ZJy9/gHrRlFMqkO6i0I3E27Alu4jjPg==",
+      "version": "22.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
+      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -534,17 +534,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.4.0.tgz",
-      "integrity": "sha512-rg8LGdv7ri3oAlenMACk9e+AR4wUV0yrrG+XKsGKOK0EVgeEDqurkXMPILG2836fW4ibokTB5v4b6Z9+GYQDEw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.5.0.tgz",
+      "integrity": "sha512-lHS5hvz33iUFQKuPFGheAB84LwcJ60G8vKnEhnfcK1l8kGVLro2SFYW6K0/tj8FUhRJ0VHyg1oAfg50QGbPPHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.4.0",
-        "@typescript-eslint/type-utils": "8.4.0",
-        "@typescript-eslint/utils": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0",
+        "@typescript-eslint/scope-manager": "8.5.0",
+        "@typescript-eslint/type-utils": "8.5.0",
+        "@typescript-eslint/utils": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -568,16 +568,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.4.0.tgz",
-      "integrity": "sha512-NHgWmKSgJk5K9N16GIhQ4jSobBoJwrmURaLErad0qlLjrpP5bECYg+wxVTGlGZmJbU03jj/dfnb6V9bw+5icsA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.5.0.tgz",
+      "integrity": "sha512-gF77eNv0Xz2UJg/NbpWJ0kqAm35UMsvZf1GHj8D9MRFTj/V3tAciIWXfmPLsAAF/vUlpWPvUDyH1jjsr0cMVWw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.4.0",
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/typescript-estree": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0",
+        "@typescript-eslint/scope-manager": "8.5.0",
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/typescript-estree": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -597,14 +597,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.4.0.tgz",
-      "integrity": "sha512-n2jFxLeY0JmKfUqy3P70rs6vdoPjHK8P/w+zJcV3fk0b0BwRXC/zxRTEnAsgYT7MwdQDt/ZEbtdzdVC+hcpF0A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.5.0.tgz",
+      "integrity": "sha512-06JOQ9Qgj33yvBEx6tpC8ecP9o860rsR22hWMEd12WcTRrfaFgHr2RB/CA/B+7BMhHkXT4chg2MyboGdFGawYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0"
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -615,14 +615,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.4.0.tgz",
-      "integrity": "sha512-pu2PAmNrl9KX6TtirVOrbLPLwDmASpZhK/XU7WvoKoCUkdtq9zF7qQ7gna0GBZFN0hci0vHaSusiL2WpsQk37A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.5.0.tgz",
+      "integrity": "sha512-N1K8Ix+lUM+cIDhL2uekVn/ZD7TZW+9/rwz8DclQpcQ9rk4sIL5CAlBC0CugWKREmDjBzI/kQqU4wkg46jWLYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.4.0",
-        "@typescript-eslint/utils": "8.4.0",
+        "@typescript-eslint/typescript-estree": "8.5.0",
+        "@typescript-eslint/utils": "8.5.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -640,9 +640,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.4.0.tgz",
-      "integrity": "sha512-T1RB3KQdskh9t3v/qv7niK6P8yvn7ja1mS7QK7XfRVL6wtZ8/mFs/FHf4fKvTA0rKnqnYxl/uHFNbnEt0phgbw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.5.0.tgz",
+      "integrity": "sha512-qjkormnQS5wF9pjSi6q60bKUHH44j2APxfh9TQRXK8wbYVeDYYdYJGIROL87LGZZ2gz3Rbmjc736qyL8deVtdw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -654,14 +654,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.4.0.tgz",
-      "integrity": "sha512-kJ2OIP4dQw5gdI4uXsaxUZHRwWAGpREJ9Zq6D5L0BweyOrWsL6Sz0YcAZGWhvKnH7fm1J5YFE1JrQL0c9dd53A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.5.0.tgz",
+      "integrity": "sha512-vEG2Sf9P8BPQ+d0pxdfndw3xIXaoSjliG0/Ejk7UggByZPKXmJmw3GW5jV2gHNQNawBUyfahoSiCFVov0Ruf7Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/visitor-keys": "8.4.0",
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/visitor-keys": "8.5.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -683,16 +683,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.4.0.tgz",
-      "integrity": "sha512-swULW8n1IKLjRAgciCkTCafyTHHfwVQFt8DovmaF69sKbOxTSFMmIZaSHjqO9i/RV0wIblaawhzvtva8Nmm7lQ==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.5.0.tgz",
+      "integrity": "sha512-6yyGYVL0e+VzGYp60wvkBHiqDWOpT63pdMV2CVG4LVDd5uR6q1qQN/7LafBZtAtNIn/mqXjsSeS5ggv/P0iECw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.4.0",
-        "@typescript-eslint/types": "8.4.0",
-        "@typescript-eslint/typescript-estree": "8.4.0"
+        "@typescript-eslint/scope-manager": "8.5.0",
+        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/typescript-estree": "8.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -706,13 +706,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.4.0.tgz",
-      "integrity": "sha512-zTQD6WLNTre1hj5wp09nBIDiOc2U5r/qmzo7wxPn4ZgAjHql09EofqhF9WF+fZHzL5aCyaIpPcT2hyxl73kr9A==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.5.0.tgz",
+      "integrity": "sha512-yTPqMnbAZJNy2Xq2XU8AdtOW9tJIr+UQb64aXB9f3B1498Zx9JorVgFJcZpEc9UBuCCrdzKID2RGAMkYcDtZOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.4.0",
+        "@typescript-eslint/types": "8.5.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -5571,9 +5571,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   "devDependencies": {
     "@types/chai": "4.3.19",
     "@types/mocha": "10.0.7",
-    "@types/node": "22.5.2",
+    "@types/node": "22.5.4",
     "@types/glob": "8.1.0",
     "@types/minimatch": "5.1.2",
-    "@typescript-eslint/eslint-plugin": "8.4.0",
-    "@typescript-eslint/parser": "8.4.0",
+    "@typescript-eslint/eslint-plugin": "8.5.0",
+    "@typescript-eslint/parser": "8.5.0",
     "chai": "4.4.1",
     "clean-webpack-plugin": "4.0.0",
     "eslint": "8.57.0",
@@ -58,7 +58,7 @@
     "nodemon": "3.1.4",
     "ts-loader": "9.5.1",
     "ts-node": "10.9.2",
-    "typescript": "5.5.4",
+    "typescript": "5.6.2",
     "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "npm-check-updates": "17.1.1"


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ @types/node                       22.5.2  →  22.5.4
⬆️ @typescript-eslint/eslint-plugin   8.4.0  →   8.5.0
⬆️ @typescript-eslint/parser          8.4.0  →   8.5.0
⬆️ typescript                         5.5.4  →   5.6.2