### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "2.0.19",
       "license": "MIT",
       "devDependencies": {
-        "@types/chai": "5.0.0",
+        "@types/chai": "5.0.1",
         "@types/glob": "8.1.0",
         "@types/minimatch": "5.1.2",
         "@types/mocha": "10.0.9",
-        "@types/node": "22.7.8",
-        "@typescript-eslint/eslint-plugin": "8.11.0",
-        "@typescript-eslint/parser": "8.11.0",
+        "@types/node": "22.8.2",
+        "@typescript-eslint/eslint-plugin": "8.12.2",
+        "@typescript-eslint/parser": "8.12.2",
         "chai": "4.4.1",
         "clean-webpack-plugin": "4.0.0",
         "eslint": "8.57.0",
@@ -25,7 +25,7 @@
         "eslint-webpack-plugin": "4.2.0",
         "mocha": "10.7.3",
         "nodemon": "3.1.7",
-        "npm-check-updates": "17.1.4",
+        "npm-check-updates": "17.1.9",
         "ts-loader": "9.5.1",
         "ts-node": "10.9.2",
         "typescript": "5.6.3",
@@ -416,9 +416,19 @@
       "license": "MIT"
     },
     "node_modules/@types/chai": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.0.0.tgz",
-      "integrity": "sha512-+DwhEHAaFPPdJ2ral3kNHFQXnTfscEEFsUxzD+d7nlcLrFK23JtNjH71RGasTcHb88b4vVi4mTyfpf8u2L8bdA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.0.1.tgz",
+      "integrity": "sha512-5T8ajsg3M/FOncpLYW7sdOcD6yf4+722sze/tc4KQV0P8Z2rAr3SAuHCIkYmYpt8VbcQlnz8SxlOlPQYefe4cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -507,13 +517,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.7.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.8.tgz",
-      "integrity": "sha512-a922jJy31vqR5sk+kAdIENJjHblqcZ4RmERviFsER4WJcEONqxKcjNOlk0q7OUfrF5sddT+vng070cdfMlrPLg==",
+      "version": "22.8.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.2.tgz",
+      "integrity": "sha512-NzaRNFV+FZkvK/KLCsNdTvID0SThyrs5SHB6tsD/lajr22FGC73N2QeDPM2wHtVde8mgcXuSsHQkH5cX1pbPLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/yargs": {
@@ -534,17 +544,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.11.0.tgz",
-      "integrity": "sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==",
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.12.2.tgz",
+      "integrity": "sha512-gQxbxM8mcxBwaEmWdtLCIGLfixBMHhQjBqR8sVWNTPpcj45WlYL2IObS/DNMLH1DBP0n8qz+aiiLTGfopPEebw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.11.0",
-        "@typescript-eslint/type-utils": "8.11.0",
-        "@typescript-eslint/utils": "8.11.0",
-        "@typescript-eslint/visitor-keys": "8.11.0",
+        "@typescript-eslint/scope-manager": "8.12.2",
+        "@typescript-eslint/type-utils": "8.12.2",
+        "@typescript-eslint/utils": "8.12.2",
+        "@typescript-eslint/visitor-keys": "8.12.2",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -568,16 +578,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.11.0.tgz",
-      "integrity": "sha512-lmt73NeHdy1Q/2ul295Qy3uninSqi6wQI18XwSpm8w0ZbQXUpjCAWP1Vlv/obudoBiIjJVjlztjQ+d/Md98Yxg==",
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.12.2.tgz",
+      "integrity": "sha512-MrvlXNfGPLH3Z+r7Tk+Z5moZAc0dzdVjTgUgwsdGweH7lydysQsnSww3nAmsq8blFuRD5VRlAr9YdEFw3e6PBw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.11.0",
-        "@typescript-eslint/types": "8.11.0",
-        "@typescript-eslint/typescript-estree": "8.11.0",
-        "@typescript-eslint/visitor-keys": "8.11.0",
+        "@typescript-eslint/scope-manager": "8.12.2",
+        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/typescript-estree": "8.12.2",
+        "@typescript-eslint/visitor-keys": "8.12.2",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -597,14 +607,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.11.0.tgz",
-      "integrity": "sha512-Uholz7tWhXmA4r6epo+vaeV7yjdKy5QFCERMjs1kMVsLRKIrSdM6o21W2He9ftp5PP6aWOVpD5zvrvuHZC0bMQ==",
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.12.2.tgz",
+      "integrity": "sha512-gPLpLtrj9aMHOvxJkSbDBmbRuYdtiEbnvO25bCMza3DhMjTQw0u7Y1M+YR5JPbMsXXnSPuCf5hfq0nEkQDL/JQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.11.0",
-        "@typescript-eslint/visitor-keys": "8.11.0"
+        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/visitor-keys": "8.12.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -615,14 +625,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.11.0.tgz",
-      "integrity": "sha512-ItiMfJS6pQU0NIKAaybBKkuVzo6IdnAhPFZA/2Mba/uBjuPQPet/8+zh5GtLHwmuFRShZx+8lhIs7/QeDHflOg==",
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.12.2.tgz",
+      "integrity": "sha512-bwuU4TAogPI+1q/IJSKuD4shBLc/d2vGcRT588q+jzayQyjVK2X6v/fbR4InY2U2sgf8MEvVCqEWUzYzgBNcGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.11.0",
-        "@typescript-eslint/utils": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.12.2",
+        "@typescript-eslint/utils": "8.12.2",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -640,9 +650,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.11.0.tgz",
-      "integrity": "sha512-tn6sNMHf6EBAYMvmPUaKaVeYvhUsrE6x+bXQTxjQRp360h1giATU0WvgeEys1spbvb5R+VpNOZ+XJmjD8wOUHw==",
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.12.2.tgz",
+      "integrity": "sha512-VwDwMF1SZ7wPBUZwmMdnDJ6sIFk4K4s+ALKLP6aIQsISkPv8jhiw65sAK6SuWODN/ix+m+HgbYDkH+zLjrzvOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -654,14 +664,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.11.0.tgz",
-      "integrity": "sha512-yHC3s1z1RCHoCz5t06gf7jH24rr3vns08XXhfEqzYpd6Hll3z/3g23JRi0jM8A47UFKNc3u/y5KIMx8Ynbjohg==",
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.12.2.tgz",
+      "integrity": "sha512-mME5MDwGe30Pq9zKPvyduyU86PH7aixwqYR2grTglAdB+AN8xXQ1vFGpYaUSJ5o5P/5znsSBeNcs5g5/2aQwow==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.11.0",
-        "@typescript-eslint/visitor-keys": "8.11.0",
+        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/visitor-keys": "8.12.2",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -683,16 +693,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.11.0.tgz",
-      "integrity": "sha512-CYiX6WZcbXNJV7UNB4PLDIBtSdRmRI/nb0FMyqHPTQD1rMjA0foPLaPUV39C/MxkTd/QKSeX+Gb34PPsDVC35g==",
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.12.2.tgz",
+      "integrity": "sha512-UTTuDIX3fkfAz6iSVa5rTuSfWIYZ6ATtEocQ/umkRSyC9O919lbZ8dcH7mysshrCdrAM03skJOEYaBugxN+M6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.11.0",
-        "@typescript-eslint/types": "8.11.0",
-        "@typescript-eslint/typescript-estree": "8.11.0"
+        "@typescript-eslint/scope-manager": "8.12.2",
+        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/typescript-estree": "8.12.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -706,13 +716,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.11.0.tgz",
-      "integrity": "sha512-EaewX6lxSjRJnc+99+dqzTeoDZUfyrA52d2/HRrkI830kgovWsmIiTfmr0NZorzqic7ga+1bS60lRBUgR3n/Bw==",
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.12.2.tgz",
+      "integrity": "sha512-PChz8UaKQAVNHghsHcPyx1OMHoFRUEA7rJSK/mDhdq85bk+PLsUHUBqTQTFt18VJZbmxBovM65fezlheQRsSDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/types": "8.12.2",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -4082,9 +4092,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "17.1.4",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.4.tgz",
-      "integrity": "sha512-crOUeN2GngqlkRCFQ/zi1zsneWd9IGZgIfAWYGAuhYiPnfbBTmJBL7Yq1wI0e1dsW8CfWc+h348WmfCREqeOBA==",
+      "version": "17.1.9",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.9.tgz",
+      "integrity": "sha512-Gfv5S8NNJKTilM1gesFNYka6bUaBs5LnVyPjApXPQphHijrlLFDMw1uSmwYMZbvJSkLZSOx03e8CHcG0Td5SMA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5609,9 +5619,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.19.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.6.tgz",
-      "integrity": "sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
   "homepage": "https://github.com/DailyBotHQ/search-text-highlight#readme",
   "dependencies": {},
   "devDependencies": {
-    "@types/chai": "5.0.0",
+    "@types/chai": "5.0.1",
     "@types/mocha": "10.0.9",
-    "@types/node": "22.7.8",
+    "@types/node": "22.8.2",
     "@types/glob": "8.1.0",
     "@types/minimatch": "5.1.2",
-    "@typescript-eslint/eslint-plugin": "8.11.0",
-    "@typescript-eslint/parser": "8.11.0",
+    "@typescript-eslint/eslint-plugin": "8.12.2",
+    "@typescript-eslint/parser": "8.12.2",
     "chai": "4.4.1",
     "clean-webpack-plugin": "4.0.0",
     "eslint": "8.57.0",
@@ -61,7 +61,7 @@
     "typescript": "5.6.3",
     "webpack": "5.95.0",
     "webpack-cli": "5.1.4",
-    "npm-check-updates": "17.1.4"
+    "npm-check-updates": "17.1.9"
   },
   "engines": {
     "node": "20.16.0"


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ @types/chai                        5.0.0  →   5.0.1
⬆️ @types/node                       22.7.8  →  22.8.2
⬆️ @typescript-eslint/eslint-plugin  8.11.0  →  8.12.2
⬆️ @typescript-eslint/parser         8.11.0  →  8.12.2
⬆️ npm-check-updates                 17.1.4  →  17.1.9