### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/glob": "8.1.0",
         "@types/minimatch": "5.1.2",
         "@types/mocha": "10.0.10",
-        "@types/node": "22.15.17",
+        "@types/node": "22.15.19",
         "@typescript-eslint/eslint-plugin": "8.32.1",
         "@typescript-eslint/parser": "8.32.1",
         "chai": "4.4.1",
@@ -23,13 +23,13 @@
         "eslint-plugin-import": "2.31.0",
         "eslint-plugin-prettier": "5.4.0",
         "eslint-webpack-plugin": "5.0.1",
-        "mocha": "11.2.2",
+        "mocha": "11.4.0",
         "nodemon": "3.1.10",
         "npm-check-updates": "18.0.1",
         "ts-loader": "9.5.2",
         "ts-node": "10.9.2",
         "typescript": "5.8.3",
-        "webpack": "5.99.8",
+        "webpack": "5.99.9",
         "webpack-cli": "6.0.1"
       },
       "engines": {
@@ -645,9 +645,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
-      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
+      "version": "22.15.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
+      "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2042,9 +2042,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4067,16 +4067,16 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.2.2.tgz",
-      "integrity": "sha512-VlSBxrPYHK4YNOEbFdkCxHQbZMoNzBkoPprqtZRW6311EUF/DlSxoycE2e/2NtRk4WKkIXzyrXDTrlikJMWgbw==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.4.0.tgz",
+      "integrity": "sha512-O6oi5Y9G6uu8f9iqXR6iKNLWHLRex3PKbmHynfpmUnMJJGrdgXh8ZmS85Ei5KR2Gnl+/gQ9s+Ktv5CqKybNw4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^5.2.0",
+        "diff": "^7.0.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
@@ -5927,9 +5927,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.99.8",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.8.tgz",
-      "integrity": "sha512-lQ3CPiSTpfOnrEGeXDwoq5hIGzSjmwD72GdfVzF7CQAI7t47rJG9eDWvcEkEn3CUQymAElVvDg3YNTlCYj+qUQ==",
+      "version": "5.99.9",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
+      "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/chai": "5.2.2",
     "@types/mocha": "10.0.10",
-    "@types/node": "22.15.17",
+    "@types/node": "22.15.19",
     "@types/glob": "8.1.0",
     "@types/minimatch": "5.1.2",
     "@typescript-eslint/eslint-plugin": "8.32.1",
@@ -54,12 +54,12 @@
     "eslint-plugin-prettier": "5.4.0",
     "eslint-config-prettier": "10.1.5",
     "eslint-webpack-plugin": "5.0.1",
-    "mocha": "11.2.2",
+    "mocha": "11.4.0",
     "nodemon": "3.1.10",
     "ts-loader": "9.5.2",
     "ts-node": "10.9.2",
     "typescript": "5.8.3",
-    "webpack": "5.99.8",
+    "webpack": "5.99.9",
     "webpack-cli": "6.0.1",
     "npm-check-updates": "18.0.1"
   },


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ @types/node  22.15.17  →  22.15.19
⬆️ mocha          11.2.2  →    11.4.0
⬆️ webpack        5.99.8  →    5.99.9