### PR TITLE
ci: harden workflows against script injection from PR fields

### DIFF
--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -62,13 +62,14 @@ jobs:
           done
 
       - name: Step 3 - 🧪🧪 Calculate PR Size and Label
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           CURRENT_SIZE="${{ steps.check_pr_size_label_step.outputs.size_label_found }}"
-          PR_BASE_REF=${{ github.event.pull_request.base.ref }}
-          PR_HEAD_REF=${{ github.event.pull_request.head.ref }}
-          git fetch origin $PR_BASE_REF
-          git fetch origin $PR_HEAD_REF
-          CHANGES_STATS=$(git diff --shortstat origin/$PR_BASE_REF..origin/$PR_HEAD_REF)
+          git fetch origin "$PR_BASE_REF"
+          git fetch origin "$PR_HEAD_REF"
+          CHANGES_STATS=$(git diff --shortstat "origin/$PR_BASE_REF..origin/$PR_HEAD_REF")
           echo $CHANGES_STATS
           LINES_CHANGED=$(echo $CHANGES_STATS | awk '{print $4+$6}')
           echo "Lines changed: $LINES_CHANGED"
@@ -134,9 +135,10 @@ jobs:
           fi
 
       - name: Step 4 - 🧪🧪🧪 Check "TITLE" length
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           MIN_TITLE_LENGTH=10
-          PR_TITLE="${{ github.event.pull_request.title }}"
           TITLE_LENGTH=$(echo -n "$PR_TITLE" | wc -c)
           if [ "$TITLE_LENGTH" -lt "$MIN_TITLE_LENGTH" ]; then
             echo "Pull request title is too short. It must have at least $MIN_TITLE_LENGTH characters."
@@ -144,9 +146,10 @@ jobs:
           fi
 
       - name: Step 5 - 🧪🧪🧪🧪 Check "BODY" length
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           MIN_BODY_LENGTH=30
-          PR_BODY='${{ github.event.pull_request.body }}'
           BODY_LENGTH=$(echo -n "$PR_BODY" | wc -c)
           if [ "$BODY_LENGTH" -lt "$MIN_BODY_LENGTH" ]; then
             echo "Pull request body is too short. It must have at least $MIN_BODY_LENGTH characters."

--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -79,19 +79,19 @@ jobs:
       - name: Step 1 - 🔔 Send notification on channel
         env:
           SIZE_LABEL_FOUND: ${{ needs.check_pr_size_label.outputs.size_label_found }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           NOTIFICATION_MESSAGE="> *WorkFlow: <https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|$GITHUB_WORKFLOW>*"$'\n'
           NOTIFICATION_MESSAGE+="> *Repository:* <https://github.com/$GITHUB_REPOSITORY|$GITHUB_REPOSITORY>"$'\n'
           NOTIFICATION_MESSAGE+="> *User Actor:* $GITHUB_ACTOR"$'\n\n'
           NOTIFICATION_MESSAGE+="> *Pull request:* <https://github.com/$GITHUB_REPOSITORY/pull/${{ github.event.pull_request.number }}|#${{github.event.pull_request.number}}>"$'\n'
-          PR_TITLE='${{ github.event.pull_request.title }}'
-          PR_BODY='${{ github.event.pull_request.body }}'
-          PR_BODY=$(echo $PR_BODY | sed 's/\r/\n/g')
+          PR_BODY=$(echo "$PR_BODY" | sed 's/\r/\n/g')
           NOTIFICATION_MESSAGE+="> *Pull request size label:* $SIZE_LABEL_FOUND"$'\n'
           NOTIFICATION_MESSAGE+="> *Pull request title:*"$'\n'
           NOTIFICATION_MESSAGE+="> \`\`\`🚩 $PR_TITLE\`\`\`"$'\n'
           NOTIFICATION_MESSAGE+="> *Pull request body content:*"$'\n'
-          NOTIFICATION_MESSAGE+="> \`\`\`$(echo $PR_BODY | sed 's/⬆️/\n⬆️/g')\`\`\`"$'\n\n'
+          NOTIFICATION_MESSAGE+="> \`\`\`$(echo "$PR_BODY" | sed 's/⬆️/\n⬆️/g')\`\`\`"$'\n\n'
           NOTIFICATION_MESSAGE="*👉 #$GITHUB_RUN_NUMBER ($GITHUB_REF_NAME) - 🏁 DEPLOYMENT STARTED*"$'\n\n'"$NOTIFICATION_MESSAGE"
           JSON_DATA=$(jq -n \
                         --arg msg "$NOTIFICATION_MESSAGE" \
@@ -294,10 +294,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Step 8 - 🗑️ Deleting source branch
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           PR_MERGED=$(jq --raw-output .pull_request.merged "$GITHUB_EVENT_PATH")
           if [ "$PR_MERGED" = "true" ]; then
-            git push origin --delete "${{ github.event.pull_request.head.ref }}"
+            git push origin --delete "$PR_HEAD_REF"
           fi
 
     outputs:
@@ -340,6 +342,8 @@ jobs:
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
           SIZE_LABEL_FOUND: ${{ needs.check_pr_size_label.outputs.size_label_found }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           NOTIFICATION_MESSAGE="> *WorkFlow: <https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|$GITHUB_WORKFLOW>*"$'\n'
           NOTIFICATION_MESSAGE+="> *Repository:* <https://github.com/$GITHUB_REPOSITORY|$GITHUB_REPOSITORY>"$'\n'
@@ -350,14 +354,12 @@ jobs:
           fi
           NOTIFICATION_MESSAGE+=""$'\n'
           NOTIFICATION_MESSAGE+="> *Pull request:* <https://github.com/$GITHUB_REPOSITORY/pull/${{ github.event.pull_request.number }}|#${{github.event.pull_request.number}}>"$'\n'
-          PR_TITLE='${{ github.event.pull_request.title }}'
-          PR_BODY='${{ github.event.pull_request.body }}'
-          PR_BODY=$(echo $PR_BODY | sed 's/\r/\n/g')
+          PR_BODY=$(echo "$PR_BODY" | sed 's/\r/\n/g')
           NOTIFICATION_MESSAGE+="> *Pull request size label:* $SIZE_LABEL_FOUND"$'\n'
           NOTIFICATION_MESSAGE+="> *Pull request title:*"$'\n'
           NOTIFICATION_MESSAGE+="> \`\`\`🚩 $PR_TITLE\`\`\`"$'\n'
           NOTIFICATION_MESSAGE+="> *Pull request body content:*"$'\n'
-          NOTIFICATION_MESSAGE+="> \`\`\`$(echo $PR_BODY | sed 's/⬆️/\n⬆️/g')\`\`\`"$'\n\n'
+          NOTIFICATION_MESSAGE+="> \`\`\`$(echo "$PR_BODY" | sed 's/⬆️/\n⬆️/g')\`\`\`"$'\n\n'
           NOTIFICATION_MESSAGE+="> *Jobs:*"$'\n'
           INDEX=1
           NEEDS_ORDER=("check_pr_size_label" "deploy_setup" "deploy_validate_linters_and_code_format" "deploy_tests" "build" "release_and_publish" "cleanup_caches")


### PR DESCRIPTION
## Summary

Mitigates script injection and bash failures when PR title or body (or branch refs) are inlined into `run:` blocks. User-controlled values are passed via step `env:` and read as `"$VAR"`, per [GitHub Actions hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).

## Changes

- `pull_request_check.yml`: `PR_BASE_REF`, `PR_HEAD_REF`, `PR_TITLE`, `PR_BODY`
- `release_and_publish.yml`: notification steps (`PR_TITLE`, `PR_BODY`), branch delete step (`PR_HEAD_REF`)

## Note

Same change set as proposed from `ci/workflow-injection-hardening`; this PR is from branch `fix/gha-pr-fields-env-hardening` off current `main`. Close the older PR if it is redundant.
