### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "search-text-highlight",
-  "version": "2.0.78",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "search-text-highlight",
-      "version": "2.0.78",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-text-highlight",
-  "version": "2.0.78",
+  "version": "2.1.0",
   "description": "This tool allow find a string or substring from a text and highlight it with html wrapper with unicode support.",
   "keywords": [
     "search",


### PR DESCRIPTION
## Summary

Bumps package version to **2.1.0** (minor) and keeps `package-lock.json` in sync with `package.json`.

## Notes

- Branch is merged with current `main` (includes latest release baseline).
- No API or dependency changes—version only.
